### PR TITLE
fix: import path

### DIFF
--- a/tests/test_mock_manager.py
+++ b/tests/test_mock_manager.py
@@ -1,5 +1,5 @@
 import unittest
-from MockManager import MockManager
+from sdk_mocks import MockManager
 import os  # Import the module to be mocked
 
 class TestOSMockMethodsExist(unittest.TestCase):

--- a/tests/test_os_mock.py
+++ b/tests/test_os_mock.py
@@ -1,5 +1,5 @@
 import unittest
-from MockManager import MockManager
+from sdk_mocks import MockManager
 import os 
 
 


### PR DESCRIPTION
Fixed module name to import from, In example `tests/` directory

- Before

```sh
$ python -m unittest discover -s tests
  File "/home/skokado/PythonSDKMocks/tests/test_os_mock.py", line 2, in <module>
    from MockManager import MockManager
ModuleNotFoundError: No module named 'MockManager'


----------------------------------------------------------------------
Ran 2 tests in 0.000s

FAILED (errors=2)
```

- After

```
Ran 7 tests in 0.001s

OK
```